### PR TITLE
Fix manual installation section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ sudo zypper install git cmake gcc-c++ extra-cmake-modules libqt5-qttools-devel l
 # Manual installation
 ```
 git clone https://github.com/a-parhom/LightlyShaders
-
+cd LightlyShaders
 git checkout v2.0
 
-cd LightlyShaders; mkdir qt5build; cd qt5build; cmake ../ -DCMAKE_INSTALL_PREFIX=/usr && make && sudo make install && (kwin_x11 --replace &)
+mkdir qt5build; cd qt5build; cmake ../ -DCMAKE_INSTALL_PREFIX=/usr && make && sudo make install && (kwin_x11 --replace &)
 ```
 
 ## Note


### PR DESCRIPTION
Checkout v2.0 branch after entering the directory `git clone` cloned the repository into. Currently, the commands compile the master branch instead of v2.0.