### PR TITLE
Configure newly connected screens in paintScreen

### DIFF
--- a/src/lightlyshaders/lightlyshaders.cpp
+++ b/src/lightlyshaders/lightlyshaders.cpp
@@ -44,9 +44,9 @@ static void ensureResources()
 
 namespace KWin {
 
-KWIN_EFFECT_FACTORY_SUPPORTED_ENABLED(  LightlyShadersEffect, 
-                                        "lightlyshaders.json", 
-                                        return LightlyShadersEffect::supported();, 
+KWIN_EFFECT_FACTORY_SUPPORTED_ENABLED(  LightlyShadersEffect,
+                                        "lightlyshaders.json",
+                                        return LightlyShadersEffect::supported();,
                                         return LightlyShadersEffect::enabledByDefault();)
 
 LightlyShadersEffect::LightlyShadersEffect() : OffscreenEffect()
@@ -109,12 +109,12 @@ LightlyShadersEffect::windowAdded(EffectWindow *w)
     QRectF maximized_area = effects->clientArea(MaximizeArea, w);
     if (maximized_area == w->frameGeometry() && m_disabledForMaximized)
         m_windows[w].skipEffect = true;
-    
+
     redirect(w);
     setShader(w, m_shader.get());
 }
 
-void 
+void
 LightlyShadersEffect::windowFullScreenChanged(EffectWindow *w)
 {
     if(w->isFullScreen()) {
@@ -124,8 +124,8 @@ LightlyShadersEffect::windowFullScreenChanged(EffectWindow *w)
     }
 }
 
-void 
-LightlyShadersEffect::windowMaximizedStateChanged(EffectWindow *w, bool horizontal, bool vertical) 
+void
+LightlyShadersEffect::windowMaximizedStateChanged(EffectWindow *w, bool horizontal, bool vertical)
 {
     if (!m_disabledForMaximized) return;
 
@@ -202,6 +202,11 @@ LightlyShadersEffect::paintScreen(int mask, const QRegion &region, ScreenPaintDa
 
     bool set_roundness = false;
 
+    if (!m_screens[s].configured) {
+        m_screens[s].configured = true;
+        set_roundness = true;
+    }
+
     qreal scale = effects->renderTargetScale();
 
     if(scale != m_screens[s].scale) {
@@ -212,7 +217,7 @@ LightlyShadersEffect::paintScreen(int mask, const QRegion &region, ScreenPaintDa
     if(set_roundness) {
         setRoundness(m_roundness, s);
         m_helper->reconfigure();
-    } 
+    }
 
     effects->paintScreen(mask, region, data);
 }
@@ -229,7 +234,7 @@ LightlyShadersEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, 
     EffectScreen *s = w->screen();
     if (effects->waylandDisplay() == nullptr) {
         s = nullptr;
-    } 
+    }
 
     const QRectF geo(w->frameGeometry());
     for (int corner = 0; corner < LSHelper::NTex; ++corner)
@@ -243,7 +248,7 @@ LightlyShadersEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, 
                 reg.translate(geo.x() + geo.width() - m_size, geo.y()-m_shadowOffset);
                 break;
             case LSHelper::BottomRight:
-                reg.translate(geo.x() + geo.width() - m_size-1, geo.y()+geo.height()-m_size-1); 
+                reg.translate(geo.x() + geo.width() - m_size-1, geo.y()+geo.height()-m_size-1);
                 break;
             case LSHelper::BottomLeft:
                 reg.translate(geo.x()-m_shadowOffset+1, geo.y()+geo.height()-m_size-1);
@@ -251,7 +256,7 @@ LightlyShadersEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, 
             default:
                 break;
         }
-        
+
         data.opaque -= reg;
     }
 
@@ -273,7 +278,7 @@ LightlyShadersEffect::isValidWindow(EffectWindow *w)
 
 void
 LightlyShadersEffect::drawWindow(EffectWindow* w, int mask, const QRegion& region, WindowPaintData& data)
-{    
+{
     QRectF screen = QRectF(effects->renderTargetRect());
 
     if (!isValidWindow(w) || (!screen.intersects(w->frameGeometry()) && !(mask & PAINT_WINDOW_TRANSFORMED)) )
@@ -326,7 +331,7 @@ LightlyShadersEffect::drawWindow(EffectWindow* w, int mask, const QRegion& regio
     m_shader->setUniform(isSquircleLocation, (m_cornersType == LSHelper::SquircledCorners));
 
     glActiveTexture(GL_TEXTURE0);
-    
+
     OffscreenEffect::drawWindow(w, mask, region, data);
 
     sm->popShader();

--- a/src/lightlyshaders/lightlyshaders.h
+++ b/src/lightlyshaders/lightlyshaders.h
@@ -37,7 +37,7 @@ public:
 
     static bool supported();
     static bool enabledByDefault();
-    
+
     void setRoundness(const int r, EffectScreen *s);
     void reconfigure(ReconfigureFlags flags) override;
     void paintScreen(int mask, const QRegion &region, ScreenPaintData &data) override;
@@ -62,6 +62,7 @@ private:
 
     struct LSScreenStruct
     {
+        bool configured=false;
         qreal scale=1.0;
         float sizeScaled;
     };
@@ -86,4 +87,3 @@ private:
 } // namespace KWin
 
 #endif //LIGHTLYSHADERS_H
-


### PR DESCRIPTION
Fixes #121. This issue was really bothering me, so I decided to fix it myself :)

Added a "configured" field to LSScreenStruct, that is initially false and represents a new monitor, and a check for that field in paintScreen, that reconfigures the effect when such monitor is detected.

Sorry for a lot of trailing spaces removed, vscode does this automatically on save.