### PR TITLE
fix(cmake): Resolve missing Qt6::CorePrivate link target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ include(KDECompilerSettings NO_POLICY_SCOPE)
 find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS
     Gui
     Core
+    CorePrivate
     DBus
     UiTools
     Widgets


### PR DESCRIPTION
The build was failing with a "target was not found" error for Qt6::CorePrivate. This occurs when a project requires private Qt headers/symbols but does not explicitly request the component in the find_package call.

By adding `CorePrivate` to the list of components, CMake can correctly locate and link the library.